### PR TITLE
Use cargo tauri for CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
         rustup component add --toolchain stable rustfmt clippy
         rustup default stable
 
+    - name: Install Tauri CLI
+      run: cargo install tauri-cli --locked
+
     - name: Install dependencies
       working-directory: apps/desktop
       run: bun install
@@ -60,4 +63,4 @@ jobs:
 
     - name: Run Tauri build
       working-directory: apps/desktop
-      run: bun run tauri build
+      run: cargo tauri build


### PR DESCRIPTION
## Summary
- install the Rust-based Tauri CLI in the CI workflow to avoid missing native npm bindings
- invoke `cargo tauri build` during the desktop app build step

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f51d100e24832db4c2cafa0dfb2102