### PR TITLE
Fix Brave browser profile path for Linux

### DIFF
--- a/apps/desktop/src-tauri/src/browser_details.rs
+++ b/apps/desktop/src-tauri/src/browser_details.rs
@@ -164,7 +164,7 @@ pub fn get_chrome_profiles(
         Browsers::Brave => [
             "BraveSoftware\\Brave-Browser\\User Data\\Local State",
             "BraveSoftware/Brave-Browser/Local State",
-            "brave/Local State",
+            "BraveSoftware/Brave-Browser/Local State",
         ],
         _ => return Ok(Vec::new()),
     };


### PR DESCRIPTION
Fixes #47 
This PR fixes the file path used to locate Brave browser profiles on Linux systems.  
Previously, the path was incorrect, causing the application to fail when detecting Brave profiles.  

Changes:  
- Updated the Browsers::Brave path entries to match Linux profile locations.  

This change only affects Brave on Linux and does not impact other browsers or platforms.
